### PR TITLE
[歌詞リリ](lyrical-nonsense.com) への対応を追加

### DIFF
--- a/src/js/KashiKaikin.user.js
+++ b/src/js/KashiKaikin.user.js
@@ -549,6 +549,18 @@ var site_infomations = [
         }
     }
 
+,   { // ■ [歌詞リリ](https://www.lyrical-nonsense.com/)
+        reg_url : '^https://(www\.)?lyrical-nonsense\.com/lyrics/.*'
+    ,   sample_url : 'https://www.lyrical-nonsense.com/lyrics/remioromen/konayuki/'
+    ,   options : {
+            jquery : true
+        }
+    ,   main : function(w, d, global_options, options) {
+            $('.olyrictext, .olyrictext-tv').off("contextmenu");
+            $('.olyrictext, .olyrictext-tv').css( global_options.CSS_ENABLE_SELECTION );
+        }
+    }
+
 /* // 雛形
 ,   { // ■
         reg_url : ''

--- a/src/js/KashiKaikin.user.js
+++ b/src/js/KashiKaikin.user.js
@@ -550,7 +550,7 @@ var site_infomations = [
     }
 
 ,   { // ■ [歌詞リリ](https://www.lyrical-nonsense.com/)
-        reg_url : '^https://(www\.)?lyrical-nonsense\.com/lyrics/.*'
+        reg_url : '^https://(www\.)?lyrical-nonsense\.com/(global/)?lyrics/.*'
     ,   sample_url : 'https://www.lyrical-nonsense.com/lyrics/remioromen/konayuki/'
     ,   options : {
             jquery : true


### PR DESCRIPTION
[歌詞リリ](lyrical-nonsense.com)がコピペ不可になったので。